### PR TITLE
ci(deploy): add Cloudflare Containers deployment option

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,5 @@ node_modules
 
 *.log
 build-errors.log
+
+cloudflare/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+          build-mode: autobuild
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:go"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   govulncheck:
@@ -37,6 +38,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.5
+
       - name: Run Trivy vulnerability scanner (filesystem)
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -46,6 +50,7 @@ jobs:
           exit-code: '0'  # Don't fail the build, just report
           format: 'sarif'
           output: 'trivy-results.sarif'
+          skip-setup-trivy: 'true'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
@@ -60,6 +65,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.5
+
       - name: Run Trivy configuration scanner
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -68,6 +76,7 @@ jobs:
           exit-code: '0'  # Don't fail the build, just report
           format: 'sarif'
           output: 'trivy-config-results.sarif'
+          skip-setup-trivy: 'true'
 
       - name: Upload Trivy config results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,18 +39,23 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.5
+        run: |
+          sudo apt-get install -y wget gnupg
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install -y trivy
 
       - name: Run Trivy vulnerability scanner (filesystem)
         uses: aquasecurity/trivy-action@0.34.1
         with:
+          skip-setup-trivy: 'true'
           scan-type: 'fs'
           scan-ref: '.'
           severity: 'CRITICAL,HIGH'
           exit-code: '0'  # Don't fail the build, just report
           format: 'sarif'
           output: 'trivy-results.sarif'
-          skip-setup-trivy: 'true'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
@@ -66,17 +71,22 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.5
+        run: |
+          sudo apt-get install -y wget gnupg
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update
+          sudo apt-get install -y trivy
 
       - name: Run Trivy configuration scanner
         uses: aquasecurity/trivy-action@0.34.1
         with:
+          skip-setup-trivy: 'true'
           scan-type: 'config'
           scan-ref: '.'
           exit-code: '0'  # Don't fail the build, just report
           format: 'sarif'
           output: 'trivy-config-results.sarif'
-          skip-setup-trivy: 'true'
 
       - name: Upload Trivy config results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "mcp-helm-cloudflare",
+  "private": true,
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250620.0"
+  }
+}

--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -1,0 +1,18 @@
+import { Container } from "cloudflare:workers";
+
+interface Env {
+  MCP_HELM: DurableObjectNamespace<McpHelmContainer>;
+}
+
+export class McpHelmContainer extends Container {
+  defaultPort = 8012;
+  sleepAfter = "5m";
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const id = env.MCP_HELM.idFromName("default");
+    const stub = env.MCP_HELM.get(id);
+    return stub.fetch(request);
+  },
+};

--- a/cloudflare/tsconfig.json
+++ b/cloudflare/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -1,0 +1,17 @@
+name = "mcp-helm"
+main = "src/index.ts"
+compatibility_date = "2025-06-01"
+
+[[containers]]
+class_name = "McpHelmContainer"
+image = "../Dockerfile"
+max_instances = 10
+instance_type = "basic"
+
+[[durable_objects.bindings]]
+name = "MCP_HELM"
+class_name = "McpHelmContainer"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["McpHelmContainer"]

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -2,6 +2,10 @@ name = "mcp-helm"
 main = "src/index.ts"
 compatibility_date = "2025-06-01"
 
+[[routes]]
+pattern = "helm-mcp.kubedoll.com"
+custom_domain = true
+
 [[containers]]
 class_name = "McpHelmContainer"
 image = "../Dockerfile"


### PR DESCRIPTION
## Summary
- Add `cloudflare/` subdirectory with Worker shim, Wrangler config, and TypeScript setup for deploying mcp-helm on Cloudflare's edge network using Containers (Firecracker microVMs)
- Reuses existing Dockerfile as-is — no Go code or Dockerfile changes needed
- Idle containers auto-sleep after 5 minutes to save cost
- Added `cloudflare/` to `.dockerignore` so it doesn't affect existing Docker builds

## Test plan
- [x] `go test ./...` — all tests pass, unaffected
- [x] `docker build .` — builds successfully, `cloudflare/` excluded via `.dockerignore`
- [ ] `cd cloudflare && npx wrangler deploy --dry-run` — validates config parses (requires wrangler auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)