### PR TITLE
release: v0.1.2-rc0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ docs/llms/work/*
 node_modules/
 
 .wrangler/
+.mcp.json


### PR DESCRIPTION
## Summary
Release candidate addressing MCP connectivity, CI security, and code quality.

### Fixes
- **MCP connectivity**: Return JSON 404 for unmatched routes (OAuth discovery) and rewrite 202 empty-body responses to 200 (Cloudflare Containers proxy limitation)
- **YAML path parser panic**: Recover from upstream `goccy/go-yaml` panic on malformed path expressions (found by fuzzing)

### Security hardening
- Pin all GitHub Actions to SHA (47 Scorecard Pinned-Dependencies findings)
- Pin Docker base images to digest
- Scope all workflow permissions to least privilege (3 Scorecard Token-Permissions findings)
- Add non-root user to Dockerfiles (Trivy DS-0002)
- Add HEALTHCHECK to Dockerfiles (Trivy DS-0026)

### Testing
- Add 5 Go fuzz targets covering YAML collapse, path extraction, host pattern matching, CSV parsing, and flag-to-env name conversion (Scorecard Fuzzing finding)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Pre-commit hooks pass on all commits
- [x] Fuzz tests run 10s+ without crashes
- [x] Deployed to `helm-mcp.kubedoll.com` — full MCP session lifecycle verified
- [x] Claude Code MCP connection confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)