### PR TITLE
fix(deps): bump Go to 1.26.1 for stdlib security patches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: '1.26'
           cache: true
 
       - name: Install mise

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: '1.26'
           cache: true
 
       - name: Install mise

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: '1.26'
           cache: true
 
       - name: Setup QEMU

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Install govulncheck

--- a/.github/workflows/test-platform.yml
+++ b/.github/workflows/test-platform.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: '1.26'
           cache: true
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: '1.26'
           cache: true
 
       - name: Run unit tests with coverage
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: '1.26'
           cache: true
 
       - name: Run integration tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,17 @@ EXPOSE 8012
 
 COPY --from=build /out/mcp-helm /mcp-helm
 
+USER nonroot
+
 ENTRYPOINT ["/mcp-helm"]
 CMD ["--listen=:8012", "--transport=http"]
 
 FROM alpine:3.23.3 AS debug
 
 RUN apk add --no-cache ca-certificates tzdata curl
+
+RUN adduser -D -u 65534 nonroot
+USER nonroot
 
 EXPOSE 8012
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 
 FROM golang:${GO_VERSION}-trixie AS build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,12 +48,11 @@ FROM alpine:3.23.3 AS debug
 
 RUN apk add --no-cache ca-certificates tzdata curl
 
-RUN adduser -D -u 65534 nonroot
-USER nonroot
-
 EXPOSE 8012
 
 COPY --from=build /out/mcp-helm /mcp-helm
+
+USER nobody
 
 ENTRYPOINT ["/mcp-helm"]
 CMD ["--listen=:8012", "--transport=http"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kubedoll-Heavy-Industries/helm-mcp
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Kubedoll-Heavy-Industries/helm-mcp
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Summary
- Bumps Go from 1.25 to 1.26.1 across go.mod, Dockerfile, and CI workflows
- Fixes 4 stdlib vulnerabilities flagged by govulncheck (GO-2026-4599 through GO-2026-4602)

## Context
These commits were pushed to `release/v0.1.3` after PR #14 was already merged, so they didn't make it onto main. This PR cherry-picks them to unblock PR #15 (release-please).

## Test plan
- [ ] CI govulncheck passes
- [ ] All existing tests pass with Go 1.26.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)