### PR TITLE
feat: add MCP registry metadata for official publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ LABEL org.opencontainers.image.title="mcp-helm" \
   org.opencontainers.image.source=$SOURCE \
   org.opencontainers.image.version=$VERSION \
   org.opencontainers.image.revision=$COMMIT \
-  org.opencontainers.image.created=$DATE
+  org.opencontainers.image.created=$DATE \
+  io.modelcontextprotocol.server.name="io.github.kubedoll-heavy-industries/helm-mcp"
 
 EXPOSE 8012
 

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -12,10 +12,12 @@ ARG SOURCE=https://github.com/Kubedoll-Heavy-Industries/helm-mcp
 
 LABEL org.opencontainers.image.title="mcp-helm" \
   org.opencontainers.image.description="MCP server for interacting with Helm repositories and charts" \
+  org.opencontainers.image.licenses="MIT" \
   org.opencontainers.image.source=$SOURCE \
   org.opencontainers.image.version=$VERSION \
   org.opencontainers.image.revision=$COMMIT \
-  org.opencontainers.image.created=$DATE
+  org.opencontainers.image.created=$DATE \
+  io.modelcontextprotocol.server.name="io.github.kubedoll-heavy-industries/helm-mcp"
 
 EXPOSE      8012
 USER        65532:65532

--- a/server.json
+++ b/server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.kubedoll-heavy-industries/helm-mcp",
+  "title": "Helm MCP",
+  "description": "Give your AI assistant access to real Helm chart data. No more hallucinated values.yaml files.",
+  "repository": {
+    "url": "https://github.com/Kubedoll-Heavy-Industries/helm-mcp",
+    "source": "github"
+  },
+  "version": "0.1.3",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://helm-mcp.kubedoll.com/mcp"
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/kubedoll-heavy-industries/mcp-helm:v0.1.3@sha256:7dc0c1dbb18030e6e111f13943cb06581deaa5b2fe5f7b6cb62313f416d3bdfa",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Kubedoll-Heavy-Industries/helm-mcp",
     "source": "github"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "remotes": [
     {
       "type": "streamable-http",
@@ -17,7 +17,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/kubedoll-heavy-industries/mcp-helm:v0.1.3@sha256:7dc0c1dbb18030e6e111f13943cb06581deaa5b2fe5f7b6cb62313f416d3bdfa",
+      "identifier": "ghcr.io/kubedoll-heavy-industries/mcp-helm:v0.1.4",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Adds `server.json` for publishing to the official MCP Registry (registry.modelcontextprotocol.io)
- Registers both the hosted remote endpoint (`helm-mcp.kubedoll.com/mcp`) and the OCI package (`ghcr.io`)
- Adds `io.modelcontextprotocol.server.name` label to both Dockerfiles for OCI ownership verification

## Publishing steps (after merge)
1. `brew install mcp-publisher`
2. `mcp-publisher login github`
3. `mcp-publisher publish`

## Test plan
- [ ] CI passes
- [ ] `mcp-publisher publish --dry-run` validates server.json (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)