### PR TITLE
fix: update server.json to v0.2.0

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/Kubedoll-Heavy-Industries/helm-mcp",
     "source": "github"
   },
-  "version": "0.1.4",
+  "version": "0.2.0",
   "remotes": [
     {
       "type": "streamable-http",
@@ -17,7 +17,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/kubedoll-heavy-industries/mcp-helm:v0.1.4",
+      "identifier": "ghcr.io/kubedoll-heavy-industries/mcp-helm:v0.2.0",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Update MCP registry metadata version from 0.1.4 to 0.2.0 to match the actual release
- Release-please bumped to minor version due to `feat:` commit in PR #38

## Test plan
- [ ] Verify server.json version matches released tag v0.2.0
- [ ] Pin OCI digest after release workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)