### PR TITLE
chore: pin OCI digest for v0.1.4 in server.json

### DIFF
--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/kubedoll-heavy-industries/mcp-helm:v0.1.4",
+      "identifier": "ghcr.io/kubedoll-heavy-industries/mcp-helm:v0.1.4@sha256:63f1504c7019726ff25caece480eabf69a015304fef5ccd80a8fd278d7ade71f",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Pin the v0.1.4 container image digest in MCP registry metadata for reproducibility

## Test plan
- [ ] Verify digest matches published image

🤖 Generated with [Claude Code](https://claude.com/claude-code)