### PR TITLE
chore: fix server.json name casing for registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.kubedoll-heavy-industries/helm-mcp",
+  "name": "io.github.Kubedoll-Heavy-Industries/helm-mcp",
   "title": "Helm MCP",
   "description": "Give your AI assistant access to real Helm chart data. No more hallucinated values.yaml files.",
   "repository": {
@@ -12,15 +12,6 @@
     {
       "type": "streamable-http",
       "url": "https://helm-mcp.kubedoll.com/mcp"
-    }
-  ],
-  "packages": [
-    {
-      "registryType": "oci",
-      "identifier": "ghcr.io/kubedoll-heavy-industries/mcp-helm:v0.1.4@sha256:63f1504c7019726ff25caece480eabf69a015304fef5ccd80a8fd278d7ade71f",
-      "transport": {
-        "type": "stdio"
-      }
     }
   ]
 }

--- a/server.json
+++ b/server.json
@@ -17,7 +17,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/kubedoll-heavy-industries/mcp-helm:v0.1.4",
+      "identifier": "ghcr.io/kubedoll-heavy-industries/mcp-helm:v0.1.4@sha256:63f1504c7019726ff25caece480eabf69a015304fef5ccd80a8fd278d7ade71f",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary
- Fix org name casing to match MCP Registry permissions (`Kubedoll-Heavy-Industries`)
- Remove OCI package — OCI identifiers are lowercase-only, creating an unresolvable case mismatch with the registry
- Successfully published v0.1.4 with remote endpoint to the official MCP Registry

## Test plan
- [x] `mcp-publisher validate` passes
- [x] `mcp-publisher publish` succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)